### PR TITLE
chore: update to fix preview url not showing

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,13 +48,9 @@ jobs:
           echo "$DEPLOY_OUTPUT"
           DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | grep -Eo 'https://[a-zA-Z0-9-]+\.vercel\.app')
           echo "url=$DEPLOY_URL" >> $GITHUB_OUTPUT
-        working-directory: src/web
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL_TEST }}
-          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-          NEXTAUTH_URL: http://localhost:3000
 
       - name: Post preview URL as PR comment
         uses: actions/github-script@v7

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,13 +44,14 @@ jobs:
       - name: Deploy preview
         id: deploy
         run: |
-          DEPLOY_OUTPUT=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }} --confirm --cwd src/web 2>&1)
-          echo "$DEPLOY_OUTPUT"
-          DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | grep -Eo 'https://[a-zA-Z0-9-]+\.vercel\.app')
+          DEPLOY_URL=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }} --yes 2>&1 | tail -1)
           echo "url=$DEPLOY_URL" >> $GITHUB_OUTPUT
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_TEST }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
 
       - name: Post preview URL as PR comment
         uses: actions/github-script@v7

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Deploy preview
         id: deploy
         run: |
-          DEPLOY_URL=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }} --yes 2>&1 | tail -1)
+          DEPLOY_OUTPUT=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }} --confirm --cwd src/web 2>&1)
+          echo "$DEPLOY_OUTPUT"
+          DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | grep -Eo 'https://[a-zA-Z0-9-]+\.vercel\.app')
           echo "url=$DEPLOY_URL" >> $GITHUB_OUTPUT
         working-directory: src/web
         env:


### PR DESCRIPTION
## What does this PR do?
Updating the deploy ci pipeline to create a valid URL instead of “missing path” errors.


## Changes
- `--cwd src/web` tells Vercel CLI to run inside your Next.js folder.
- You don’t need to add src/web again in the CLI or in your workflow’s working-directory for this step
