### PR TITLE
chore: enable ecs deploys on both main and pilot branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to ECS
 
 on:
   push:
-    branches: [main]
+    branches: [main, pilot]
 
 jobs:
   deploy:


### PR DESCRIPTION
Updated GitHub Actions workflow to trigger deployments when pushing to either the main or pilot branches, instead of only main. This allows for deployment testing and releases from the pilot branch as well.
