### PR TITLE
chore: update ECS task to use valueFrom for sensitive env vars

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "ConnectionStrings__DefaultConnection",
-          "value": "arn:aws:iam::012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
+          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
         },
         {
           "name": "Jwt__Issuer",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Jwt__SecretKey",
-          "value": "arn:aws:iam::012834916544:parameter/beddin/production/Jwt__SecretKey"
+          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/Jwt__SecretKey"
         },
         {
           "name": "Jwt__Audience",


### PR DESCRIPTION
## What does this PR do?
Switched "ConnectionStrings__DefaultConnection" and "Jwt__SecretKey" environment variables in the ECS task definition to use the "valueFrom" field. This change ensures sensitive values are securely retrieved from AWS Parameter Store or Secrets Manager at runtime instead of being hardcoded.
