### PR TITLE
chore: updates sensitive environment variables 

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "ConnectionStrings__DefaultConnection",
-          "value": "arn:aws:iam::012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
+          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
         },
         {
           "name": "Jwt__Issuer",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Jwt__SecretKey",
-          "value": "arn:aws:iam::012834916544:parameter/beddin/production/Jwt__SecretKey"
+          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/Jwt__SecretKey"
         },
         {
           "name": "Jwt__Audience",


### PR DESCRIPTION
## What does this PR do?
This pull request updates how sensitive environment variables are provided in the `task-definition.json` file, switching from hardcoded values to using the `valueFrom` property. This change improves security by referencing secrets stored in AWS Parameter Store instead of embedding them directly.