### PR TITLE
chore: Secret configuration updates

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -28,7 +28,7 @@
       "secrets": [
         {
           "name": "Jwt__ExpirationMinutes",
-          "value": "20"
+          "valueFrom": "20"
         },
         {
           "name": "ConnectionStrings__DefaultConnection",
@@ -36,11 +36,11 @@
         },
         {
           "name": "Jwt__Issuer",
-          "value": "Beddin"
+          "valueFrom": "Beddin"
         },
         {
           "name": "Jwt__RefreshTokenExpiryMinutes",
-          "value": "10080"
+          "valueFrom": "10080"
         },
         {
           "name": "Jwt__SecretKey",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Jwt__Audience",
-          "value": "BeddinUsers"
+          "valueFrom": "BeddinUsers"
         }
       ],
       "environmentFiles": [],


### PR DESCRIPTION
## What does this PR do?
This pull request updates the way several secret values are provided in the `task-definition.json` file. Instead of using the `value` field for some secrets, the configuration now uses the `valueFrom` field for consistency with how other secrets are referenced.

Secret configuration updates:

* Changed the fields for `Jwt__ExpirationMinutes`, `Jwt__Issuer`, `Jwt__RefreshTokenExpiryMinutes`, and `Jwt__Audience` from `value` to `valueFrom` to standardize how secret values are provided in `task-definition.json`.