### PR TITLE
chore: emove enableFaultInjection from task-definition.json

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -117,6 +117,5 @@
   },
   "registeredAt": "2026-03-25T17:16:31.482Z",
   "registeredBy": "arn:aws:iam::012834916544:root",
-  "enableFaultInjection": false,
   "tags": []
 }


### PR DESCRIPTION
## What does this PR do?
The enableFaultInjection property was deleted from the ECS task definition file, as it is no longer required.