### PR TITLE
chore: removing the `enableFaultInjection` property

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -117,6 +117,5 @@
   },
   "registeredAt": "2026-03-25T17:16:31.482Z",
   "registeredBy": "arn:aws:iam::012834916544:root",
-  "enableFaultInjection": false,
   "tags": []
 }


### PR DESCRIPTION
## What does this PR do?
This pull request makes a minor change to the `task-definition.json` file by removing the `enableFaultInjection` property. This simplifies the task definition and removes an unused or unnecessary configuration option.