### PR TITLE
chore: Update env var ARNs to use SSM format with region

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "ConnectionStrings__DefaultConnection",
-          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
         },
         {
           "name": "Jwt__Issuer",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Jwt__SecretKey",
-          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/Jwt__SecretKey"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__SecretKey"
         },
         {
           "name": "Jwt__Audience",


### PR DESCRIPTION
## What does this PR do?
Changed valueFrom ARNs for ConnectionStrings__DefaultConnection and Jwt__SecretKey in task-definition.json to use the SSM Parameter Store format. This ensures correct secret retrieval from AWS SSM.