### PR TITLE
chore: updates sensitive environment variables

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "ConnectionStrings__DefaultConnection",
-          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/ConnectionStrings__DefaultConnection"
         },
         {
           "name": "Jwt__Issuer",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Jwt__SecretKey",
-          "valueFrom": "arn:aws:iam::012834916544:parameter/beddin/production/Jwt__SecretKey"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__SecretKey"
         },
         {
           "name": "Jwt__Audience",


### PR DESCRIPTION
## What does this PR do?
This pull request updates the way sensitive environment variables are referenced in the `task-definition.json` file. Specifically, it changes the `valueFrom` ARNs for certain secrets to use AWS Systems Manager (SSM) Parameter Store in the `eu-north-1` region, instead of using IAM parameter ARNs.

Secret management updates:

* Updated the `valueFrom` ARN for `ConnectionStrings__DefaultConnection` to use SSM Parameter Store in the `eu-north-1` region.
* Updated the `valueFrom` ARN for `Jwt__SecretKey` to use SSM Parameter Store in the `eu-north-1` region.