### PR TITLE
chore: Configuration and secrets management

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -28,7 +28,7 @@
       "secrets": [
         {
           "name": "Jwt__ExpirationMinutes",
-          "valueFrom": "20"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__ExpirationMinutes"
         },
         {
           "name": "ConnectionStrings__DefaultConnection",
@@ -36,11 +36,11 @@
         },
         {
           "name": "Jwt__Issuer",
-          "valueFrom": "Beddin"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__Issuer"
         },
         {
           "name": "Jwt__RefreshTokenExpiryMinutes",
-          "valueFrom": "10080"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__RefreshTokenExpiryMinutes"
         },
         {
           "name": "Jwt__SecretKey",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Jwt__Audience",
-          "valueFrom": "BeddinUsers"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__Audience"
         }
       ],
       "environmentFiles": [],


### PR DESCRIPTION
## What does this PR do?
This pull request updates the way sensitive configuration values are sourced in the `task-definition.json` file. Instead of hardcoding values directly in the file, these secrets are now pulled from AWS SSM Parameter Store, which enhances security and centralizes configuration management.

**Configuration and secrets management:**

* Updated the `valueFrom` fields for `Jwt__ExpirationMinutes`, `Jwt__Issuer`, `Jwt__RefreshTokenExpiryMinutes`, and `Jwt__Audience` to reference their respective AWS SSM Parameter Store ARNs instead of hardcoded values. (`task-definition.json`)