### PR TITLE
chore: Apply EF Core migrations automatically at startup

### DIFF
--- a/src/api/Beddin.API/Extensions/ApplicationExtensions.cs
+++ b/src/api/Beddin.API/Extensions/ApplicationExtensions.cs
@@ -6,12 +6,37 @@ using Beddin.Infrastructure.Persistence.Seed;
 using Hangfire;
 using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using StackExchange.Redis;
 
 namespace Beddin.API.Extensions
 {
     public static class ApplicationExtensions
     {
+        public static async Task<IApplicationBuilder> ApplyMigrationsAsync(
+            this IApplicationBuilder app)
+        {
+            using var scope = app.ApplicationServices.CreateScope();
+            var services = scope.ServiceProvider;
+            var db = services.GetRequiredService<AppDbContext>();
+            var logger = services.GetRequiredService<ILogger<AppDbContext>>();
+
+            try
+            {
+                logger.LogInformation("Applying database migrations...");
+           
+                await db.Database.MigrateAsync();
+
+                logger.LogInformation("Database migrations applied");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An error occurred while applying migrations to the database");
+                throw;
+            }
+
+            return app;
+        }
         public static async Task<IApplicationBuilder> SeedDatabaseAsync(
             this IApplicationBuilder app,
             bool seedSampleData = false)

--- a/src/api/Beddin.API/Program.cs
+++ b/src/api/Beddin.API/Program.cs
@@ -20,6 +20,8 @@ app.UseApiMiddleware();
 // Map health check endpoint for ECS
 app.MapHealthChecks("/api/health");
 
+await app.ApplyMigrationsAsync();
+
 app.Run();
 
 public partial class Program { }

--- a/src/api/Beddin.Domain/Aggregates/Users/User.cs
+++ b/src/api/Beddin.Domain/Aggregates/Users/User.cs
@@ -28,7 +28,9 @@ namespace Beddin.Domain.Aggregates.Users
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
 
+#pragma warning disable CS0649
         private Role? _role;
+#pragma warning restore CS0649
         public Role Role => _role!;
 
         private readonly List<Property> _listings = new();


### PR DESCRIPTION
## What does this PR do?
Added ApplyMigrationsAsync extension method to handle automatic application of pending EF Core database migrations on startup, with logging and error handling. Updated Program.cs to invoke this method before app.Run(). Added necessary using directive for Microsoft.EntityFrameworkCore.