### PR TITLE
chore: Refactor DB migration logic to use MigrationHandler

### DIFF
--- a/src/api/Beddin.API/Extensions/ApplicationExtensions.cs
+++ b/src/api/Beddin.API/Extensions/ApplicationExtensions.cs
@@ -7,6 +7,7 @@ using Hangfire;
 using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Npgsql;
 using StackExchange.Redis;
 
@@ -14,107 +15,24 @@ namespace Beddin.API.Extensions
 {
     public static class ApplicationExtensions
     {
-        // Fixed advisory lock key used to elect a single migration leader across replicas.
-        // Value is derived from the ASCII encoding of "beddin-migrate" to minimise the chance
-        // of colliding with advisory locks used by other tools (e.g. Hangfire, pg_partman).
-        private const long MigrationAdvisoryLockKey = 7367473L;
-
-        // How long a non-leader replica waits for the leader to finish migrations.
-        private static readonly TimeSpan MigrationLockTimeout = TimeSpan.FromMinutes(2);
-
-        // How often non-leader replicas poll to check whether the leader has finished.
-        private static readonly TimeSpan MigrationLockPollInterval = TimeSpan.FromSeconds(5);
-
+        
         public static async Task<IApplicationBuilder> ApplyMigrationsAsync(
             this IApplicationBuilder app)
         {
             using var scope = app.ApplicationServices.CreateScope();
             var services = scope.ServiceProvider;
-            var configuration = services.GetRequiredService<IConfiguration>();
-            var logger = services.GetRequiredService<ILogger<AppDbContext>>();
+            var logger = services.GetRequiredService<ILogger<MigrationHandler>>();
 
-            // Guard: only run automatic migrations when explicitly enabled via configuration.
-            if (!configuration.GetValue<bool>("Database:AutoMigrate"))
-            {
-                logger.LogInformation("Automatic database migration is disabled (Database:AutoMigrate is not set)");
-                return app;
-            }
-
-            var connectionString = configuration.GetConnectionString("DefaultConnection")
-                ?? throw new InvalidOperationException(
-                    "Connection string 'DefaultConnection' is not configured. " +
-                    "Database migrations cannot proceed.");
-            var db = services.GetRequiredService<AppDbContext>();
 
             try
             {
-                // Open a dedicated connection to hold the Postgres session-level advisory lock.
-                // This ensures that in a multi-replica deployment only one instance applies
-                // migrations while the others wait, preventing DDL lock contention.
-                await using var lockConnection = new NpgsqlConnection(connectionString);
-                await lockConnection.OpenAsync();
+                var context = services.GetRequiredService<AppDbContext>();
+                var configuration = services.GetRequiredService<IConfiguration>();
+                var orchestrator = new MigrationHandler(context, logger, configuration);
 
-                bool lockAcquired;
-                await using (var tryLockCmd = lockConnection.CreateCommand())
-                {
-                    tryLockCmd.CommandText = "SELECT pg_try_advisory_lock(@key)";
-                    tryLockCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                    var result = await tryLockCmd.ExecuteScalarAsync();
-                    lockAcquired = result is bool b && b;
-                }
+                logger.LogInformation("Starting database seeding...");
 
-                if (lockAcquired)
-                {
-                    try
-                    {
-                        logger.LogInformation("Migration lock acquired. Applying database migrations...");
-                        await db.Database.MigrateAsync();
-                        logger.LogInformation("Database migrations applied successfully");
-                    }
-                    finally
-                    {
-                        await using var unlockCmd = lockConnection.CreateCommand();
-                        unlockCmd.CommandText = "SELECT pg_advisory_unlock(@key)";
-                        unlockCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                        await unlockCmd.ExecuteNonQueryAsync();
-                    }
-                }
-                else
-                {
-                    // Another replica is applying migrations; poll until the lock is released.
-                    logger.LogInformation("Another instance is applying database migrations, waiting for it to complete...");
-
-                    var timeout = MigrationLockTimeout;
-                    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-                    var migrationComplete = false;
-
-                    while (stopwatch.Elapsed < timeout)
-                    {
-                        await Task.Delay(MigrationLockPollInterval);
-
-                        await using var checkCmd = lockConnection.CreateCommand();
-                        checkCmd.CommandText = "SELECT pg_try_advisory_lock(@key)";
-                        checkCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                        var checkResult = await checkCmd.ExecuteScalarAsync();
-                        var acquired = checkResult is bool b && b;
-
-                        if (acquired)
-                        {
-                            // Lock is free — the leader has finished; release immediately.
-                            await using var relCmd = lockConnection.CreateCommand();
-                            relCmd.CommandText = "SELECT pg_advisory_unlock(@key)";
-                            relCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                            await relCmd.ExecuteNonQueryAsync();
-                            migrationComplete = true;
-                            break;
-                        }
-                    }
-
-                    if (migrationComplete)
-                        logger.LogInformation("Database migrations completed by peer instance");
-                    else
-                        logger.LogWarning("Timed out waiting for peer instance to complete database migrations");
-                }
+                await orchestrator.ApplyMigrations();
             }
             catch (Exception ex)
             {

--- a/src/api/Beddin.Infrastructure/Persistence/Seed/DatabaseSeeder.cs
+++ b/src/api/Beddin.Infrastructure/Persistence/Seed/DatabaseSeeder.cs
@@ -18,6 +18,44 @@ using System.Threading.Tasks;
 
 namespace Beddin.Infrastructure.Persistence.Seed
 {
+
+    
+    public class MigrationHandler
+    {
+        private readonly AppDbContext _context;
+        private readonly ILogger<MigrationHandler> _logger;
+        private readonly IConfiguration _configuration;
+
+        public MigrationHandler(AppDbContext context, ILogger<MigrationHandler> logger, IConfiguration configuration)
+        {
+            _context = context;
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        public async Task ApplyMigrations()
+        {
+            try
+            {
+                var migrationsEnabled = _configuration.GetValue<bool>("DatabaseMigrations:Enabled", true);
+                if (!migrationsEnabled)
+                {
+                    _logger.LogInformation("Database migrations are disabled");
+                    return;
+                }
+
+                // Ensure database is created and migrations are applied
+                await _context.Database.MigrateAsync();
+
+                _logger.LogInformation("Database migrations applied successfully");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while applying migrations to the database");
+                throw;
+            }
+        }
+    }
     public class DatabaseSeeder
     {
         private readonly AppDbContext _context;


### PR DESCRIPTION
Move migration logic from ApplicationExtensions to a new MigrationHandler class, removing the PostgreSQL advisory lock mechanism. Migrations are now applied directly if enabled via the config key. This simplifies the process and centralizes migration handling and logging.