### PR TITLE
chore: refactor database migration logic

### DIFF
--- a/src/api/Beddin.API/Extensions/ApplicationExtensions.cs
+++ b/src/api/Beddin.API/Extensions/ApplicationExtensions.cs
@@ -7,6 +7,7 @@ using Hangfire;
 using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Npgsql;
 using StackExchange.Redis;
 
@@ -14,107 +15,24 @@ namespace Beddin.API.Extensions
 {
     public static class ApplicationExtensions
     {
-        // Fixed advisory lock key used to elect a single migration leader across replicas.
-        // Value is derived from the ASCII encoding of "beddin-migrate" to minimise the chance
-        // of colliding with advisory locks used by other tools (e.g. Hangfire, pg_partman).
-        private const long MigrationAdvisoryLockKey = 7367473L;
-
-        // How long a non-leader replica waits for the leader to finish migrations.
-        private static readonly TimeSpan MigrationLockTimeout = TimeSpan.FromMinutes(2);
-
-        // How often non-leader replicas poll to check whether the leader has finished.
-        private static readonly TimeSpan MigrationLockPollInterval = TimeSpan.FromSeconds(5);
-
+        
         public static async Task<IApplicationBuilder> ApplyMigrationsAsync(
             this IApplicationBuilder app)
         {
             using var scope = app.ApplicationServices.CreateScope();
             var services = scope.ServiceProvider;
-            var configuration = services.GetRequiredService<IConfiguration>();
-            var logger = services.GetRequiredService<ILogger<AppDbContext>>();
+            var logger = services.GetRequiredService<ILogger<MigrationHandler>>();
 
-            // Guard: only run automatic migrations when explicitly enabled via configuration.
-            if (!configuration.GetValue<bool>("Database:AutoMigrate"))
-            {
-                logger.LogInformation("Automatic database migration is disabled (Database:AutoMigrate is not set)");
-                return app;
-            }
-
-            var connectionString = configuration.GetConnectionString("DefaultConnection")
-                ?? throw new InvalidOperationException(
-                    "Connection string 'DefaultConnection' is not configured. " +
-                    "Database migrations cannot proceed.");
-            var db = services.GetRequiredService<AppDbContext>();
 
             try
             {
-                // Open a dedicated connection to hold the Postgres session-level advisory lock.
-                // This ensures that in a multi-replica deployment only one instance applies
-                // migrations while the others wait, preventing DDL lock contention.
-                await using var lockConnection = new NpgsqlConnection(connectionString);
-                await lockConnection.OpenAsync();
+                var context = services.GetRequiredService<AppDbContext>();
+                var configuration = services.GetRequiredService<IConfiguration>();
+                var orchestrator = new MigrationHandler(context, logger, configuration);
 
-                bool lockAcquired;
-                await using (var tryLockCmd = lockConnection.CreateCommand())
-                {
-                    tryLockCmd.CommandText = "SELECT pg_try_advisory_lock(@key)";
-                    tryLockCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                    var result = await tryLockCmd.ExecuteScalarAsync();
-                    lockAcquired = result is bool b && b;
-                }
+                logger.LogInformation("Starting database seeding...");
 
-                if (lockAcquired)
-                {
-                    try
-                    {
-                        logger.LogInformation("Migration lock acquired. Applying database migrations...");
-                        await db.Database.MigrateAsync();
-                        logger.LogInformation("Database migrations applied successfully");
-                    }
-                    finally
-                    {
-                        await using var unlockCmd = lockConnection.CreateCommand();
-                        unlockCmd.CommandText = "SELECT pg_advisory_unlock(@key)";
-                        unlockCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                        await unlockCmd.ExecuteNonQueryAsync();
-                    }
-                }
-                else
-                {
-                    // Another replica is applying migrations; poll until the lock is released.
-                    logger.LogInformation("Another instance is applying database migrations, waiting for it to complete...");
-
-                    var timeout = MigrationLockTimeout;
-                    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-                    var migrationComplete = false;
-
-                    while (stopwatch.Elapsed < timeout)
-                    {
-                        await Task.Delay(MigrationLockPollInterval);
-
-                        await using var checkCmd = lockConnection.CreateCommand();
-                        checkCmd.CommandText = "SELECT pg_try_advisory_lock(@key)";
-                        checkCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                        var checkResult = await checkCmd.ExecuteScalarAsync();
-                        var acquired = checkResult is bool b && b;
-
-                        if (acquired)
-                        {
-                            // Lock is free — the leader has finished; release immediately.
-                            await using var relCmd = lockConnection.CreateCommand();
-                            relCmd.CommandText = "SELECT pg_advisory_unlock(@key)";
-                            relCmd.Parameters.AddWithValue("key", MigrationAdvisoryLockKey);
-                            await relCmd.ExecuteNonQueryAsync();
-                            migrationComplete = true;
-                            break;
-                        }
-                    }
-
-                    if (migrationComplete)
-                        logger.LogInformation("Database migrations completed by peer instance");
-                    else
-                        logger.LogWarning("Timed out waiting for peer instance to complete database migrations");
-                }
+                await orchestrator.ApplyMigrations();
             }
             catch (Exception ex)
             {

--- a/src/api/Beddin.Infrastructure/Persistence/Seed/DatabaseSeeder.cs
+++ b/src/api/Beddin.Infrastructure/Persistence/Seed/DatabaseSeeder.cs
@@ -18,6 +18,44 @@ using System.Threading.Tasks;
 
 namespace Beddin.Infrastructure.Persistence.Seed
 {
+
+    
+    public class MigrationHandler
+    {
+        private readonly AppDbContext _context;
+        private readonly ILogger<MigrationHandler> _logger;
+        private readonly IConfiguration _configuration;
+
+        public MigrationHandler(AppDbContext context, ILogger<MigrationHandler> logger, IConfiguration configuration)
+        {
+            _context = context;
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        public async Task ApplyMigrations()
+        {
+            try
+            {
+                var migrationsEnabled = _configuration.GetValue<bool>("DatabaseMigrations:Enabled", true);
+                if (!migrationsEnabled)
+                {
+                    _logger.LogInformation("Database migrations are disabled");
+                    return;
+                }
+
+                // Ensure database is created and migrations are applied
+                await _context.Database.MigrateAsync();
+
+                _logger.LogInformation("Database migrations applied successfully");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while applying migrations to the database");
+                throw;
+            }
+        }
+    }
     public class DatabaseSeeder
     {
         private readonly AppDbContext _context;

--- a/task-definition.json
+++ b/task-definition.json
@@ -23,9 +23,53 @@
         {
           "name": "ASPNETCORE_URLS",
           "value": "http://+:8080"
-        }
+        },
+        {
+          "name": "Features__AdminPanel",
+          "value": "true"
+        },
+        {
+          "name": "Features__Authentication",
+          "value": "true"
+        },
+        {
+          "name": "Features__AuditLog",
+          "value": "true"
+        },
+        {
+          "name": "DatabaseMigrations__Enabled",
+          "value": "true"
+        },
+        {
+          "name": "EmailOptions__BaseUrl",
+          "value": "https://checkonetwo.com/api"
+        },
+        {
+          "name": "EmailOptions__FromEmail",
+          "value": "noreply@habitera.homes"
+        },
+        {
+          "name": "EmailOptions__FromName",
+          "value": "Habitera"
+        },
+        {
+          "name": "EmailOptions__Port",
+          "value": "587"
+        },
+        {
+          "name": "EmailOptions__SmtpServer",
+          "value": "smtp-relay.brevo.com"
+        },
       ],
       "secrets": [
+        {
+          "name": "EmailOptions__Username",
+          "value": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Username"
+        },
+        {
+          "name": "EmailOptions__Password",
+          "value": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Password"
+        },
         {
           "name": "Jwt__ExpirationMinutes",
           "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/Jwt__ExpirationMinutes"


### PR DESCRIPTION
## What does this PR do?
This pull request refactors the database migration logic to simplify and centralize migration handling. The migration orchestration code is moved from the `ApplicationExtensions` class into a new `MigrationHandler` class, making the codebase cleaner and easier to maintain. The advisory lock mechanism for multi-replica scenarios is removed, and migration configuration is now controlled by a single flag.

**Refactoring and migration handling:**

* Moved the migration orchestration logic from `ApplicationExtensions` to a new `MigrationHandler` class in `DatabaseSeeder.cs`, encapsulating migration behavior and improving separation of concerns. [[1]](diffhunk://#diff-9c3f5e3f783389d962fb1dfeda24900f159d4a4855dc27be9937503528591f4fR10-R35) [[2]](diffhunk://#diff-1ffd4a3af91765c9526a37774d25b70072310d51cbfef9c27f882cb123aec4dbR21-R58)
* Removed the Postgres advisory lock logic and related polling, simplifying the migration process and eliminating the leader election mechanism for migrations across replicas.

**Configuration and logging:**

* Changed the configuration flag for enabling migrations from `Database:AutoMigrate` to `DatabaseMigrations:Enabled`, and defaulted it to `true` if not set.
* Improved logging by centralizing migration logs within the new `MigrationHandler`. [[1]](diffhunk://#diff-9c3f5e3f783389d962fb1dfeda24900f159d4a4855dc27be9937503528591f4fR10-R35) [[2]](diffhunk://#diff-1ffd4a3af91765c9526a37774d25b70072310d51cbfef9c27f882cb123aec4dbR21-R58)