### PR TITLE
chore: Update ECS secrets to use valueFrom for SSM parameters

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -64,11 +64,11 @@
       "secrets": [
         {
           "name": "EmailOptions__Username",
-          "value": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Username"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Username"
         },
         {
           "name": "EmailOptions__Password",
-          "value": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Password"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Password"
         },
         {
           "name": "Jwt__ExpirationMinutes",


### PR DESCRIPTION
Switched EmailOptions__Username and EmailOptions__Password in task-definition.json from "value" to "valueFrom" to properly reference secrets from AWS SSM Parameter Store. This ensures secrets are securely retrieved at runtime by ECS.
