### PR TITLE
chore: update to the task-definition

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -64,11 +64,11 @@
       "secrets": [
         {
           "name": "EmailOptions__Username",
-          "value": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Username"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Username"
         },
         {
           "name": "EmailOptions__Password",
-          "value": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Password"
+          "valueFrom": "arn:aws:ssm:eu-north-1:012834916544:parameter/beddin/production/EmailOptions__Password"
         },
         {
           "name": "Jwt__ExpirationMinutes",


### PR DESCRIPTION
## What does this PR do?
This pull request makes a minor but important update to the `task-definition.json` file, correcting the way secrets are referenced for environment variables. The change ensures that secrets are securely fetched from AWS Systems Manager Parameter Store using the correct property.

- Changed the `secrets` configuration to use `valueFrom` instead of `value` for the `EmailOptions__Username` and `EmailOptions__Password` environment variables, ensuring proper retrieval of secrets from AWS SSM Parameter Store.