### PR TITLE
chore: Reorder ASP.NET Core env vars in task-definition.json

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -17,14 +17,6 @@
       "essential": true,
       "environment": [
         {
-          "name": "ASPNETCORE_ENVIRONMENT",
-          "value": "Production"
-        },
-        {
-          "name": "ASPNETCORE_URLS",
-          "value": "http://+:8080"
-        },
-        {
           "name": "Features__AdminPanel",
           "value": "true"
         },
@@ -59,6 +51,14 @@
         {
           "name": "EmailOptions__SmtpServer",
           "value": "smtp-relay.brevo.com"
+        },
+        {
+          "name": "ASPNETCORE_ENVIRONMENT",
+          "value": "Production"
+        },
+        {
+          "name": "ASPNETCORE_URLS",
+          "value": "http://+:8080"
         }
       ],
       "secrets": [


### PR DESCRIPTION
Moved ASPNETCORE_ENVIRONMENT and ASPNETCORE_URLS to a later position in the environment array without changing their values.