### PR TITLE
chore: adjustments to the ordering of environment variables 

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -17,14 +17,6 @@
       "essential": true,
       "environment": [
         {
-          "name": "ASPNETCORE_ENVIRONMENT",
-          "value": "Production"
-        },
-        {
-          "name": "ASPNETCORE_URLS",
-          "value": "http://+:8080"
-        },
-        {
           "name": "Features__AdminPanel",
           "value": "true"
         },
@@ -59,6 +51,14 @@
         {
           "name": "EmailOptions__SmtpServer",
           "value": "smtp-relay.brevo.com"
+        },
+        {
+          "name": "ASPNETCORE_ENVIRONMENT",
+          "value": "Production"
+        },
+        {
+          "name": "ASPNETCORE_URLS",
+          "value": "http://+:8080"
         }
       ],
       "secrets": [


### PR DESCRIPTION
## What does this PR do?
This pull request makes minor adjustments to the ordering of environment variables in the `task-definition.json` file. The environment variables `ASPNETCORE_ENVIRONMENT` and `ASPNETCORE_URLS` were moved further down in the list, but their values remain unchanged. No functional changes are introduced.