### PR TITLE
fix: Log AdminPanel flag; default feature flags to enabled

### DIFF
--- a/src/api/Beddin.API/Program.cs
+++ b/src/api/Beddin.API/Program.cs
@@ -10,6 +10,9 @@ builder.Services.AddApiServices(builder.Configuration);
 
 var app = builder.Build();
 
+var flagValue = app.Configuration.GetValue<bool>("Features:AdminPanel");
+app.Logger.LogInformation("Features:AdminPanel = {Value}", flagValue);
+
 await app.ApplyMigrationsAsync();
 
 if (app.Environment.IsDevelopment())

--- a/src/api/Beddin.Application/Common/Behaviours/FeatureFlagBehavior.cs
+++ b/src/api/Beddin.Application/Common/Behaviours/FeatureFlagBehavior.cs
@@ -30,7 +30,7 @@ namespace Beddin.Application.Common.Behaviours
             if (request is not IRequiresFeature flagged)
                 return await next();
 
-            var isEnabled = _config.GetValue<bool>(flagged.FeatureFlag);
+            var isEnabled = _config.GetValue<bool?>(flagged.FeatureFlag) ?? true;
 
             if (!isEnabled)
             {


### PR DESCRIPTION
Added logging of the Features:AdminPanel config value at startup for better visibility. Updated feature flag behavior to default to enabled (true) when a flag is not set in configuration, instead of defaulting to false. This ensures features are enabled unless explicitly disabled.